### PR TITLE
can ommit "isa" key in spec object

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -26,11 +26,13 @@ var types = 'array boolean date element empty finite function null \
     _normalizeValidationSpec = function(validationSpec) {
         var normalized = {};
 
-        _.keys(validationSpec).forEach(function(key) {
+        _.each(validationSpec, function(value, key) {
             normalized[key] = _.extend({
-                    optional: false,
-                    isa: null
-                }, validationSpec[key]);
+                optional: false,
+                isa: null
+            }, _.isString(value) ? {
+                isa: value
+            } : value);
         });
 
         return normalized;
@@ -83,7 +85,7 @@ var Validate = {
      * Perform validation against one of the builtin types: whole, real, natural
      *
      * @param {number} value A number to check
-     * @param {string} name Type name: whole, real, natural
+     * @param {string} typeName Type name: whole, real, natural
      * @return {bool} True or false, false if name is not one of "whole, real, natural"
      */
     isValidOfType: function(value, typeName) {
@@ -99,7 +101,7 @@ var Validate = {
      * Validate a single value against a given validation spec
      *
      * @param {any} value Value to validate
-     * @param {object} Validation spec { isa: 'what', optional: bool }
+     * @param {object} rawSpec Validation spec { isa: 'what', optional: bool }
      * @return {bool} true or false
      */
     isValid: function(value, rawSpec) {
@@ -139,7 +141,7 @@ var Validate = {
 
 
         if ((_.isArray(posArguments) || _.isArguments(posArguments))) {
-            var validation = _.map( validationSpec, function(validation, index) {
+            var validation = _.map( normalized, function(validation, index) {
                 return Validate.isValid(posArguments[index], validation) ? null : index;
             });
 
@@ -169,7 +171,7 @@ var Validate = {
 
         if (_.isPlainObject(namedArguments)) {
             errors = _.filter(_.keys(validationSpec), function(key) {
-                return Validate.isValid(namedArguments[key], validationSpec[key]) ? false : true;
+                return !Validate.isValid(namedArguments[key], normalized[key]);
             });
 
             return validationObject(errors, namedArguments, normalized);

--- a/test/validate.js
+++ b/test/validate.js
@@ -279,4 +279,28 @@ suite('validate-arguments', function() {
 
     });
 
+    test('"isa" key can be omitted', function(done) {
+        var validated = Validate.validateObject({
+            a: 1,
+            b: 'a',
+            c: true,
+            d: false,
+            e: random.number(),
+            f: random.integer()
+        }, {
+            a: 'number',
+            b: 'string',
+            c: 'boolean',
+            d: 'boolean',
+            e: 'number',
+            f: 'whole'
+        });
+        assert.equal(validated.isValid(), true, 'values are validated by shortened spec');
+
+        validated = Validate.validatePositional(['a'], ['string']);
+        assert.equal(validated.isValid(), true, 'values are validated by shortened spec');
+
+        done();
+    });
+
 });


### PR DESCRIPTION
When using the library I found myself creating lots of large validation objects typically looking like

```
{
    message: {
        isa: 'object'
    },
    author: {
        isa: 'object'
    },
    id: {
        isa: 'natural'
    },
    ts: {
        isa: 'number'
    }
}
```

This is great, but a bit too verbose, especially if there are lots of such code in one file. So I'd like to write it like this:

```
{
    message: 'object',
    author: 'object',
    id: 'natural',
    ts: 'number'
}
```

I've added a simple test, which doesn't cover all the scenarios, but I'd like to share the idea and know what you think. If that doesn't conflict with your vision, I can polish the pull request.
