### PR TITLE
fixes #2 (support for underscore.js)

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -8,6 +8,11 @@ var _ = require('lodash'),
         return str.charAt(0).toUpperCase() + str.slice(1);
     };
 
+// #2: support for underscore.js
+_.isPlainObject = _.isPlainObject || function(obj) {
+  return _.isObject(obj) && !_.isArray(obj) && !_.isFunction(obj);
+};
+
 /*jshint multistr: true */
 var types = 'array boolean date element empty finite function null \
             number object plainObject regexp string'.match(/(\w+)/g),

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "devDependencies": {
         "mocha": ">=1.9.0",
         "js-beautify": "~1.4.2",
-        "jshint": "*"
+        "jshint": "*",
+        "underscore": "~1.6.0",
+        "mockery": "~1.4.0"
     },
     "scripts": {
         "test": "./node_modules/mocha/bin/mocha -u tdd -R tap test"

--- a/test/validate-underscore.js
+++ b/test/validate-underscore.js
@@ -1,0 +1,14 @@
+// Tests for #2: support underscore.js
+var mockery = require('mockery');
+
+mockery.enable({
+    // avoid hitting cached lodash
+    useCleanCache: true,
+    warnOnUnregistered: false
+});
+
+// Run the same tests with underscore now
+mockery.registerSubstitute('lodash', 'underscore');
+require('./validate');
+
+mockery.disable();


### PR DESCRIPTION
Fixes support for `underscore.js` instead of `lodash.js` by mimicking the missing `isPlainObject` method.
