### PR TITLE
IE8 support

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -36,7 +36,7 @@ var Types = {
     },
 
     isPrimitive: function(value) {
-        return ['number', 'boolean', 'string'].indexOf(value) !== -1;
+        return _.indexOf(['number', 'boolean', 'string'], value) !== -1;
     }
 };
 


### PR DESCRIPTION
IE8 chokes on direct call to `Array#indexOf` call. Substituted it with `lodash.indexOf`.
