### PR TITLE
adding nested array handling and a test

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -105,6 +105,11 @@ var Validate = {
         if (typeof spec.isa === 'function')
             return (value instanceof spec.isa);
 
+        if (Array.isArray(spec.isa))
+            if (Array.isArray(value)) {
+                return Validate.validate(value, spec.isa).isValid();
+            }
+
         return false;
     },
 

--- a/test/validate.js
+++ b/test/validate.js
@@ -334,6 +334,59 @@ suite('validate-arguments', function() {
         });
     });
 
+    test('validation specs can be nested arrays!', function() {
+        // TODO add more testcases, both invalid and valid!
+        var spec = {
+            thing: {
+                isa: [{
+                    nestedThing: {
+                        isa: {
+                            childOfNested: {
+                                isa: 'string'
+                            }
+                        }
+                    },
+                    optionalThing: {
+                        optional: true,
+                        isa: 'string'
+                    }
+                }],
+                optional: true
+            }
+        };
+
+        var cases = [
+            {
+                label: 'deep nested object is validated',
+                isValid: true,
+                value: {
+                    thing: [{
+                        nestedThing: {
+                            childOfNested: random.string()
+                        }
+                    }]
+                }
+            },
+            {
+                label: 'deep nested value must be of valid type',
+                isValid: false,
+                value: {
+                    thing: [{
+                        nestedThing: {
+                            childOfNested: random.integer()
+                        }
+                    }]
+                }
+            }
+        ];
+
+        cases.map(function(testCase) {
+            var validated = Validate.validateObject(testCase.value, spec);
+
+            assert.equal(validated.isValid(), testCase.isValid, testCase.label);
+        });
+    });
+
 
     test('Validate.named is sugar for validateObject', function() {
         var cases = [


### PR DESCRIPTION
Hey there, 

This connects to #8 

This pull adds nested array handling, but it unfortunately doesn't throw the most informative errors if you do indeed have an error in the array (although I believe this is also an issue with nested object handling, so maybe there needs to be a fix for both of them).

I'd be interested in knowing if anyone has any ideas for throwing better errors for nested validation?

Thanks!
